### PR TITLE
Adds Navigation Tab for Tournament Information (Draft)

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,9 +8,14 @@
 
 <body>
   <div id="main">
-    <a href="tournament.html" class="tournament-nav-button">
-      <button>Qualifier Info &#x2728;</button>
-    </a>
+    <div class="tournament-nav-container">
+      <a href="index.html">
+        <button>Home</button>
+      </a>
+      <a href="tournament.html">
+        <button>2024 Cascadia Qualifier &#x2728;</button>
+      </a>
+    </div>
     <div class="logo">
       <img src="./img/206_seattle_bike_polo_logo.png" />
     </div>

--- a/index.html
+++ b/index.html
@@ -1,32 +1,41 @@
 <html>
-  <head>
-    <title>206 Seattle Bike Polo</title>
-    <link rel="icon" type="image/x-icon" href="./favicon.ico" />
-    <link rel="stylesheet" type="text/css" href="style.css" />
-  </head>
-  <body>
-    <div id="main">
-      <div class="logo">
-        <img src="./img/206_seattle_bike_polo_logo.png" />
-      </div>
-      <div>
-        <ul>
-          <li>We play at Judkins Park <a href="https://maps.app.goo.gl/UxkWUMPTLsNPhg5WA">47.591401,-122.302915</a></li>
-          <ul>
-            <li>Saturdays 2PM till dark</li>
-            <li>Sundays 11AM till dark</li>
-            <li>Wednesdays 6PM till dark</li>
-          </ul>
-          <li>Come out June 1st and 2nd 2024 for the <a href="https://bikepolocalendar.com/event/nah-cascadia-qualifier">Cascadia Qualifier</a></li>
-          <li><a href="https://www.instagram.com/206bikepolo/">@206bikepolo</a> on Instagram</li>
-          <li>Talk to everyone on <a href="https://join.slack.com/t/seattlebikepolo/shared_invite/zt-2im5od2df-FlTl~Oc9YVC8feu95iVM8g">Slack</a></li>
-          <li>Edit this website on <a href="">GitHub</a>. FTP and GitHub access avaialble upon request.</li>
-        </ul>
-      </div>
 
-      <img src="./img/judkins_play_times.png" />
-      <img src="./img/cascadia_qualifier_2024.png" />
-      <img src="./img/april_newbie_day.png" />
+<head>
+  <title>206 Seattle Bike Polo</title>
+  <link rel="icon" type="image/x-icon" href="./favicon.ico" />
+  <link rel="stylesheet" type="text/css" href="style.css" />
+</head>
+
+<body>
+  <div id="main">
+    <a href="tournament.html" class="tournament-nav-button">
+      <button>Qualifier Info &#x2728;</button>
+    </a>
+    <div class="logo">
+      <img src="./img/206_seattle_bike_polo_logo.png" />
     </div>
-  </body>
+    <div>
+      <ul>
+        <li>We play at Judkins Park <a href="https://maps.app.goo.gl/UxkWUMPTLsNPhg5WA">47.591401,-122.302915</a></li>
+        <ul>
+          <li>Saturdays 2PM till dark</li>
+          <li>Sundays 11AM till dark</li>
+          <li>Wednesdays 6PM till dark</li>
+        </ul>
+        <li>Come out June 1st and 2nd 2024 for the <a
+            href="https://bikepolocalendar.com/event/nah-cascadia-qualifier">Cascadia Qualifier</a></li>
+        <li><a href="https://www.instagram.com/206bikepolo/">@206bikepolo</a> on Instagram</li>
+        <li>Talk to everyone on <a
+            href="https://join.slack.com/t/seattlebikepolo/shared_invite/zt-2im5od2df-FlTl~Oc9YVC8feu95iVM8g">Slack</a>
+        </li>
+        <li>Edit this website on <a href="">GitHub</a>. FTP and GitHub access avaialble upon request.</li>
+      </ul>
+    </div>
+
+    <img src="./img/judkins_play_times.png" />
+    <img src="./img/cascadia_qualifier_2024.png" />
+    <img src="./img/april_newbie_day.png" />
+  </div>
+</body>
+
 </html>

--- a/style.css
+++ b/style.css
@@ -5,12 +5,14 @@ body {
 
 #main {
   width: 800px;
+  min-height: 80vh;
   margin: auto;
   padding: 1em;
-  margin-top: 2em;
+  margin-top: 4em;
   border: solid black 1px;
   background-color: white;
   font-family: monospace;
+  position: relative;
 }
 
 #main h1 {
@@ -29,4 +31,29 @@ img {
 .logo img {
   margin: auto;
   max-width: 60%;
+}
+
+.tournament-nav-button {
+  position: absolute;
+  top: -43px;
+  left: -1px;
+  background-color: white;
+  min-height: 45px;
+  border-radius: 6px 6px 0 0;
+
+  button {
+    font-family: monospace;
+    padding: 1em;
+    cursor: pointer;
+    border-width: 1px 1px 0;
+    background-color: white;
+    border-radius: 6px 6px 0 0;
+    min-width: 15em;
+    max-height: 43px;
+
+    &:hover {
+      background-color: #f2f2f2;
+    }
+  }
+
 }

--- a/style.css
+++ b/style.css
@@ -33,7 +33,7 @@ img {
   max-width: 60%;
 }
 
-.tournament-nav-button {
+.tournament-nav-container {
   position: absolute;
   top: -43px;
   left: -1px;
@@ -56,4 +56,9 @@ img {
     }
   }
 
+}
+
+iframe {
+  width: 100%;
+  height: 100%;
 }

--- a/tournament.html
+++ b/tournament.html
@@ -8,13 +8,16 @@
 
 <body>
   <div id="main">
-    <a href="index.html" class="tournament-nav-button">
-      <button>Back</button>
-    </a>
+    <div class="tournament-nav-container">
+      <a href="index.html">
+        <button>Home</button>
+      </a>
+      <a href="tournament.html">
+        <button>2024 Cascadia Qualifier &#x2728;</button>
+      </a>
+    </div>
     <div>
-      <ul>
-        <li>Tournament info here</li>
-      </ul>
+      <iframe src="https://docs.google.com/spreadsheets/u/0/d/1AGFDK9q0FRlkJO21pvcy2CKDlJXbh6EKetmHTl-dN0E/htmlview#"></iframe>
     </div>
   </div>
 </body>

--- a/tournament.html
+++ b/tournament.html
@@ -1,0 +1,22 @@
+<html>
+
+<head>
+  <title>206 Seattle Bike Polo</title>
+  <link rel="icon" type="image/x-icon" href="./favicon.ico" />
+  <link rel="stylesheet" type="text/css" href="style.css" />
+</head>
+
+<body>
+  <div id="main">
+    <a href="index.html" class="tournament-nav-button">
+      <button>Back</button>
+    </a>
+    <div>
+      <ul>
+        <li>Tournament info here</li>
+      </ul>
+    </div>
+  </div>
+</body>
+
+</html>


### PR DESCRIPTION
Adds a navigation tab for tournament info. Can be used for qualifiers or other upcoming tournaments if you guys like it.
We should use javascript to do this in the future, but I think this works for now. 

Open to feedback. 

<img width="1002" alt="Screen Shot 2024-05-30 at 11 02 10 PM" src="https://github.com/geluso/206bikepolo.com/assets/22123634/5f15db0d-2170-4d62-9839-bad11a471550">
<img width="1033" alt="Screen Shot 2024-05-30 at 11 02 21 PM" src="https://github.com/geluso/206bikepolo.com/assets/22123634/d7dead07-c1e1-43f6-a505-96b443aa0cfc">
