### PR TITLE
Vibe-coded hamburger menu to fix navbar issue on mobile

### DIFF
--- a/app/components/HamburgerMenu.tsx
+++ b/app/components/HamburgerMenu.tsx
@@ -1,0 +1,63 @@
+import { useState } from "react";
+
+interface Tab {
+  label: string;
+  href: string;
+}
+
+interface HamburgerMenuProps {
+  tabs: Tab[];
+}
+
+const HamburgerMenu: React.FC<HamburgerMenuProps> = ({ tabs }) => {
+  const [isOpen, setIsOpen] = useState<boolean>(false);
+
+  const toggleMenu = (): void => {
+    setIsOpen(!isOpen);
+  };
+
+  return (
+    <div className="sm:hidden relative">
+      <button
+        className="flex flex-col items-center justify-center w-8 h-8 space-y-1 focus:outline-none"
+        onClick={toggleMenu}
+        aria-label="Toggle navigation menu"
+      >
+        <span
+          className={`block w-8 h-1 bg-gray-600 transform transition-transform ${
+            isOpen ? "rotate-45 translate-y-2" : ""
+          }`}
+        ></span>
+        <span
+          className={`block w-8 h-1 bg-gray-600 transition-opacity ${
+            isOpen ? "opacity-0" : "opacity-100"
+          }`}
+        ></span>
+        <span
+          className={`block w-8 h-1 bg-gray-600 transform transition-transform ${
+            isOpen ? "-rotate-45 -translate-y-2" : ""
+          }`}
+        ></span>
+      </button>
+
+      {isOpen && (
+        <div className="absolute right-0 mt-2 w-48 bg-white shadow-lg rounded-lg">
+          <ul className="flex flex-col p-2 space-y-2">
+            {tabs.map((tab, index) => (
+              <li key={index}>
+                <a
+                  href={tab.href}
+                  className="block px-4 py-2 text-gray-800 hover:bg-gray-100"
+                >
+                  {tab.label}
+                </a>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default HamburgerMenu;

--- a/app/components/NavigationTabs.tsx
+++ b/app/components/NavigationTabs.tsx
@@ -15,7 +15,7 @@ interface NavigationTabsProps {
 const NavigationTabs: React.FC<NavigationTabsProps> = ({ tabs }) => {
   return (
     <nav className="bg-gray-900 sticky w-full z-20 top-0 start-0">
-      <div className="max-w-screen-xl flex flex-wrap items-center md:justify-between justify-evenly mx-auto p-4">
+      <div className="max-w-screen-xl flex flex-wrap items-center justify-between mx-auto p-4">
         <a href="/" className="flex items-center space-x-3">
           <span className="self-center text-2xl font-semibold whitespace-nowrap text-white">
             Seattle Bike Polo

--- a/app/components/NavigationTabs.tsx
+++ b/app/components/NavigationTabs.tsx
@@ -1,5 +1,7 @@
+'use client';
 import React from "react";
 import NavItem from "./NavItem";
+import HamburgerMenu from "./HamburgerMenu";
 
 interface Tab {
   label: string;
@@ -19,7 +21,8 @@ const NavigationTabs: React.FC<NavigationTabsProps> = ({ tabs }) => {
             Seattle Bike Polo
           </span>
         </a>
-        <div className="flex w-auto">
+        <HamburgerMenu tabs={tabs}/>
+        <div className="hidden sm:flex sm:w-auto">
           <ul className="flex space-x-2 md:space-x-8">
             {tabs.map((tab, index) => (
               <li className="mb-px mr-1" key={index}>

--- a/app/globals.css
+++ b/app/globals.css
@@ -25,7 +25,7 @@ body {
 }
 
 #main {
-  width: 800px;
+  max-width: 800px;
   font-family: monospace;
 }
 


### PR DESCRIPTION
Fix for the zoomed-in issue I was seeing on mobile. The `max-width` forces the contents of main down to fit within the viewport width on mobile, however this new width does not provide enough space for the navbar links. 

Added a hamburger menu in order to fit all navbar links on mobile.

https://github.com/user-attachments/assets/cd372b48-25af-4f60-9901-17c0e79ab07b


