### PR TITLE
Obfuscate link to slack

### DIFF
--- a/app/components/SlackLink.tsx
+++ b/app/components/SlackLink.tsx
@@ -1,0 +1,23 @@
+'use client';
+import React from "react";
+
+import { Obfuscate } from "@south-paw/react-obfuscate-ts";
+
+const SlackLink: React.FC = () => {
+  // Obfuscation to avoid spam bots. There are two places we need to
+  // obfuscate. The first is our site itself. The Obfuscate component
+  // uses javascript and css tricks to hide the link from spambots while
+  // still rendering it properly for visitors to the site.
+  // The second, and probably more important place we need to obfuscate
+  // is in the source code because this is an open source project. That's
+  // why the link only appears in the source backwards.
+  const backwardsLink = 'Q2406CmJAvtiltze2Xh2PX-vp4vrunm3-tz/etivni_derah' +
+    's/olopekibelttaes/t/moc.kcals.nioj//:sptth';
+  return (
+      <Obfuscate href={backwardsLink.split('').reverse().join('')}>
+        Slack
+      </Obfuscate>
+  );
+};
+
+export default SlackLink;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -6,6 +6,7 @@ import NAs2025Winners from "../public/img/NAs_2025_winners_first_place_gulls.jpg
 import seattleLogoImage from "../public/img/206_seattle_bike_polo_logo.png";
 import crown from "../public/img/2024_eco_3xcrown1.png";
 import NearbyEvents from "./tournaments/NearbyEvents";
+import SlackLink from "./components/SlackLink";
 
 export default function Home() {
   return (
@@ -34,9 +35,7 @@ export default function Home() {
 
       <p>
         Talk to everyone on{" "}
-        <a href="https://join.slack.com/t/seattlebikepolo/shared_invite/zt-2m8wd3zl2-RxZBe~fmA_1abfLNSAZ5yg" target="_blank">
-          Slack
-        </a>{" "}
+        <SlackLink />{" "}
         and follow us on Instagram{" "}
         <a href="https://www.instagram.com/206bikepolo/" target="_blank">
           @206bikepolo

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@neondatabase/serverless": "^1.0.0",
         "@prisma/client": "^6.5.0",
+        "@south-paw/react-obfuscate-ts": "^2.0.0",
         "next": "14.2.3",
         "react": "^18",
         "react-dom": "^18",
@@ -943,6 +944,15 @@
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.10.2.tgz",
       "integrity": "sha512-hw437iINopmQuxWPSUEvqE56NCPsiU8N4AYtfHmJFckclktzK9YQJieD3XkDCDH4OjL+C7zgPUh73R/nrcHrqw==",
       "dev": true
+    },
+    "node_modules/@south-paw/react-obfuscate-ts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@south-paw/react-obfuscate-ts/-/react-obfuscate-ts-2.0.0.tgz",
+      "integrity": "sha512-LsO2XDYr4X/osmaQEDzc3ntyEbRzCQK9apmkOTxOuxzJlmc69JrhJ/WQRizxKj+geCEcYd2cfoT5KmQC7WyfjQ==",
+      "peerDependencies": {
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0"
+      }
     },
     "node_modules/@swc/counter": {
       "version": "0.1.3",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@neondatabase/serverless": "^1.0.0",
     "@prisma/client": "^6.5.0",
+    "@south-paw/react-obfuscate-ts": "^2.0.0",
     "next": "14.2.3",
     "react": "^18",
     "react-dom": "^18",


### PR DESCRIPTION
We're tired of getting spambots so let's hide the link.

Testing: checked that the link to slack still works.
Did `curl http://localhost:3000/ -o output.txt` and verified that the link no longer appears in our page source.

